### PR TITLE
Fjern tools: latest fra CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,6 @@ jobs:
 
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
-          tools: latest
 
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).


### PR DESCRIPTION
`tools: latest` tvinger CodeQL til å bruke en eldre cachet bundle (2.25.6) som ikke støtter Kotlin 2.4.0 (`KotlinVersionTooRecentError`, støtter kun < 2.3.30). Ved å fjerne linja brukes bundlen som er innebygd i `codeql-action@v4.36.3` (2.26.0), som støtter Kotlin 2.4.0. Løser feilende Analyze-sjekk på all-deps-PR-ene.