### PR TITLE
Ignorer kafka meldinger hvor pia-dvh-import ikke er mottaker 

### DIFF
--- a/src/main/kotlin/no/nav/pia/dvhimport/importjobb/kafka/Jobblytter.kt
+++ b/src/main/kotlin/no/nav/pia/dvhimport/importjobb/kafka/Jobblytter.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import no.nav.pia.dvhimport.importjobb.ImportService
 import no.nav.pia.dvhimport.importjobb.domene.DvhMetadata
 import no.nav.pia.dvhimport.importjobb.domene.StatistikkKategori
@@ -62,10 +64,27 @@ class Jobblytter(
                     while (job.isActive) {
                         val records = consumer.poll(Duration.ofSeconds(1))
                         records.forEach {
-                            val jobbInfo = Json.decodeFromString<SerializableJobbInfo>(it.value())
-                            if (jobbInfo.jobb.name != it.key()) {
+                            val kafkaMeldingNøkkel = it.key()
+                            val kafkaMeldingVerdi = it.value()
+
+                            val json = Json.parseToJsonElement(string = kafkaMeldingVerdi)
+                            val målapplikasjon: String? = json.jsonObject["applikasjon"]?.jsonPrimitive?.content
+
+                            if (målapplikasjon != "pia-dvh-import") {
+                                logger.info(
+                                    "Mottok en Kafka melding hvor målapplikasjonen er: '$målapplikasjon' (forventer 'pia-dvh-import'). " +
+                                        "Skal ikke prosessere melding med nøkkel: '$kafkaMeldingNøkkel' og verdi: '$kafkaMeldingVerdi' " +
+                                        "fra topic '${it.topic()}' i konsummentGruppe '${
+                                            consumer.groupMetadata().groupId()
+                                        }'. ",
+                                )
+                                return@forEach
+                            }
+
+                            val jobbInfo = Json.decodeFromString<SerializableJobbInfo>(kafkaMeldingVerdi)
+                            if (jobbInfo.jobb.name != kafkaMeldingNøkkel) {
                                 logger.warn(
-                                    "Received record with key ${it.key()} and value ${it.value()} from topic ${it.topic()} but jobInfo.job is ${jobbInfo.jobb}",
+                                    "Received record with key $kafkaMeldingNøkkel and value $kafkaMeldingVerdi from topic ${it.topic()} but jobInfo.job is ${jobbInfo.jobb}",
                                 )
                             } else {
                                 val årstallOgKvartal = jobbInfo.tilÅrstallOgKvartal() ?: ÅrstallOgKvartal(2024, 2)
@@ -76,30 +95,60 @@ class Jobblytter(
                                     alleKategorierSykefraværsstatistikkDvhImport -> {
                                         importService.importAlleStatistikkKategorier(årstallOgKvartal)
                                     }
+
                                     landSykefraværsstatistikkDvhImport -> {
-                                        importService.importForStatistikkKategori(StatistikkKategori.LAND, årstallOgKvartal)
+                                        importService.importForStatistikkKategori(
+                                            StatistikkKategori.LAND,
+                                            årstallOgKvartal,
+                                        )
                                     }
+
                                     sektorSykefraværsstatistikkDvhImport -> {
-                                        importService.importForStatistikkKategori(StatistikkKategori.SEKTOR, årstallOgKvartal)
+                                        importService.importForStatistikkKategori(
+                                            StatistikkKategori.SEKTOR,
+                                            årstallOgKvartal,
+                                        )
                                     }
+
                                     næringSykefraværsstatistikkDvhImport -> {
-                                        importService.importForStatistikkKategori(StatistikkKategori.NÆRING, årstallOgKvartal)
+                                        importService.importForStatistikkKategori(
+                                            StatistikkKategori.NÆRING,
+                                            årstallOgKvartal,
+                                        )
                                     }
+
                                     næringskodeSykefraværsstatistikkDvhImport -> {
-                                        importService.importForStatistikkKategori(StatistikkKategori.NÆRINGSKODE, årstallOgKvartal)
+                                        importService.importForStatistikkKategori(
+                                            StatistikkKategori.NÆRINGSKODE,
+                                            årstallOgKvartal,
+                                        )
                                     }
+
                                     bransjeSykefraværsstatistikkDvhImport -> {
-                                        importService.importForStatistikkKategori(StatistikkKategori.BRANSJE, årstallOgKvartal)
+                                        importService.importForStatistikkKategori(
+                                            StatistikkKategori.BRANSJE,
+                                            årstallOgKvartal,
+                                        )
                                     }
+
                                     virksomhetSykefraværsstatistikkDvhImport -> {
-                                        importService.importForStatistikkKategori(StatistikkKategori.VIRKSOMHET, årstallOgKvartal)
+                                        importService.importForStatistikkKategori(
+                                            StatistikkKategori.VIRKSOMHET,
+                                            årstallOgKvartal,
+                                        )
                                     }
+
                                     virksomhetMetadataSykefraværsstatistikkDvhImport -> {
-                                        importService.importMetadata(DvhMetadata.VIRKSOMHET_METADATA, årstallOgKvartal)
+                                        importService.importMetadata(
+                                            DvhMetadata.VIRKSOMHET_METADATA,
+                                            årstallOgKvartal,
+                                        )
                                     }
+
                                     publiseringsdatoDvhImport -> {
                                         importService.importMetadata(DvhMetadata.PUBLISERINGSDATO, årstallOgKvartal)
                                     }
+
                                     else -> {
                                         logger.info("Jobb '${jobbInfo.jobb}' ignorert")
                                     }

--- a/src/test/kotlin/no/nav/pia/dvhimport/helper/KafkaContainerHelper.kt
+++ b/src/test/kotlin/no/nav/pia/dvhimport/helper/KafkaContainerHelper.kt
@@ -179,15 +179,27 @@ class KafkaContainerHelper(
         jobb: Jobb,
         parameter: String? = null,
     ) {
+        sendJobbMelding(
+            jobbnavn = jobb.name,
+            parameter = parameter,
+        )
+    }
+
+    fun sendJobbMelding(
+        jobbnavn: String,
+        tidspunkt: String? = "2023-01-01T00:00:00.000Z",
+        applikasjon: String? = "pia-dvh-import",
+        parameter: String? = null,
+    ) {
         sendOgVentTilKonsumert(
-            nøkkel = jobb.name,
+            nøkkel = jobbnavn,
             melding =
                 """
                 {
-                    "jobb": "${jobb.name}",
-                    "tidspunkt": "2023-01-01T00:00:00.000Z",
-                    "applikasjon": "pia-dvh-import",
-                    "parameter": ${parameter?.let {"\"$it\""} ?: "null"}
+                    "jobb": "$jobbnavn",
+                    "tidspunkt": "$tidspunkt",
+                    "applikasjon": "$applikasjon",
+                    "parameter": ${parameter?.let { "\"$it\"" } ?: "null"}
                 }
                 """.trimIndent(),
             topic = KafkaTopics.PIA_JOBBLYTTER,

--- a/src/test/kotlin/no/nav/pia/dvhimport/importjobb/kafka/JobblytterEdgeCasesTest.kt
+++ b/src/test/kotlin/no/nav/pia/dvhimport/importjobb/kafka/JobblytterEdgeCasesTest.kt
@@ -1,0 +1,23 @@
+package no.nav.pia.dvhimport.importjobb.kafka
+
+import ia.felles.integrasjoner.jobbsender.Jobb.iaSakEksport
+import no.nav.pia.dvhimport.helper.TestContainerHelper
+import no.nav.pia.dvhimport.helper.TestContainerHelper.Companion.dvhImportApplikasjon
+import no.nav.pia.dvhimport.helper.TestContainerHelper.Companion.shouldContainLog
+import kotlin.test.Test
+
+class JobblytterEdgeCasesTest {
+    private val kafkaContainer = TestContainerHelper.kafka
+
+    @Test
+    fun `skal ikke feile dersom meldinger er om en ukjent jobb til en annen applikasjon`() {
+        kafkaContainer.sendJobbMelding(jobbnavn = "denne-skal-få-deserializer-til-å-krasje-ved-Jobb-Enum", applikasjon = "lydia-api")
+        dvhImportApplikasjon shouldContainLog "Mottok en Kafka melding hvor målapplikasjonen er: 'lydia-api'".toRegex()
+    }
+
+    @Test
+    fun `skal ikke prosessere meldinger som ikke er til pia-dvh-import`() {
+        kafkaContainer.sendJobbMelding(jobbnavn = iaSakEksport.name, applikasjon = "lydia-api")
+        dvhImportApplikasjon shouldContainLog "Mottok en Kafka melding hvor målapplikasjonen er: 'lydia-api'".toRegex()
+    }
+}


### PR DESCRIPTION
Stå over kafka meldinger om å starte en jobb dersom meldingen ikke er adressert til applikasjon 'pia-dv-import' 